### PR TITLE
Fix always keeping the aspect ratio when cropping

### DIFF
--- a/robothub_sdk/src/robothub_sdk/device.py
+++ b/robothub_sdk/src/robothub_sdk/device.py
@@ -358,7 +358,6 @@ class Device:
             if roi is not None:
                 # If full_fov = True we do not want to keep aspect ratio
                 manip_nn.setKeepAspectRatio(not full_fov)
-                manip_nn.setKeepAspectRatio(True)
                 manip_nn.initialConfig.setCropRect(roi)
             # NN inputs
             manip_nn.out.link(nn.input)

--- a/robothub_sdk/src/robothub_sdk/device.py
+++ b/robothub_sdk/src/robothub_sdk/device.py
@@ -356,7 +356,8 @@ class Device:
 
             # Set crop if set
             if roi is not None:
-                # Setting to True prevents "Processing failed, potentially unsupported config" error
+                # If full_fov = True we do not want to keep aspect ratio
+                manip_nn.setKeepAspectRatio(not full_fov)
                 manip_nn.setKeepAspectRatio(True)
                 manip_nn.initialConfig.setCropRect(roi)
             # NN inputs

--- a/robothub_sdk/src/robothub_sdk/device.py
+++ b/robothub_sdk/src/robothub_sdk/device.py
@@ -354,6 +354,7 @@ class Device:
                 manip_nn.initialConfig.setFrameType(frame_type)
                 manip_nn.setMaxOutputFrameSize(input_size[0] * input_size[1] * 3)  # assume 3 channels UINT8 images
 
+            manip_nn.setKeepAspectRatio(True)
             # Set crop if set
             if roi is not None:
                 # If full_fov = True we do not want to keep aspect ratio


### PR DESCRIPTION
full_fov flag didn't had an effect when cropping the image. If full_fov = True we do not want to keep aspect ratio