### PR TITLE
DepthAI watchdog detection added (C-323).

### DIFF
--- a/robothub_sdk/src/robothub_sdk/app.py
+++ b/robothub_sdk/src/robothub_sdk/app.py
@@ -333,6 +333,9 @@ class App:
                 had_items = False
                 now = time.monotonic()
                 for device in self.devices:
+                    # NOTE: needs depthai>2.17.4
+                    if device.internal.isClosed():
+                        raise RuntimeError(f"Device {device.id} / {device.name} disconnected.")
                     last_item = 0
                     for stream in device.streams.outputs():
                         last_item = max(last_item, stream.last_timestamp)


### PR DESCRIPTION
RobotHub no longer waits 60 seconds before shutting down the application after the device is disconnected.